### PR TITLE
Feature reenabling mail -r option 

### DIFF
--- a/doc/PyAlarmUserGuide.rst
+++ b/doc/PyAlarmUserGuide.rst
@@ -440,8 +440,8 @@ notification list. There is also a `GobalReceivers` property which allows to def
 
 PyAlarm supports two ways of sending mails configured with the `MailMethod` class property:
 
-* using 'mail' shell command, when *MailMethod* is set to `mail`, which is default,
-* or using `smtplib` when *MailMethod* is set to `smtp[:host[:port]]`.
+* using `mail` shell command, when *MailMethod* is set to `mail`, which is default,
+* or using `smtplib` python library when *MailMethod* is set to `smtp[:host[:port]]`.
 
 As it is now, mail messages are formatted as the following:
 

--- a/doc/PyAlarmUserGuide.rst
+++ b/doc/PyAlarmUserGuide.rst
@@ -443,8 +443,10 @@ PyAlarm supports two ways of sending mails configured with the `MailMethod` clas
 * using 'mail' shell command, when *MailMethod* is set to `mail`, which is default,
 * or using `smtplib` when *MailMethod* is set to `smtp[:host[:port]]`.
 
-Format of Alarm message
+As it is now, mail messages are formatted as the following:
 
+Format of Alarm message
+-----------------------
 
 .. code-block:: python
 
@@ -465,7 +467,7 @@ Format of Alarm message
 
 
 Format of Recovered message
-
+---------------------------
 
 .. code-block:: python
 

--- a/doc/PyAlarmUserGuide.rst
+++ b/doc/PyAlarmUserGuide.rst
@@ -435,6 +435,13 @@ These will be the typical properties of a PyAlarm device
 Mail Messages
 =============
 
+PyAlarm allows to send mail notifications. Each alarm may be configured with :ref:`AlarmReceivers` property to provide
+notification list. There is also a `GobalReceivers` property which allows to define notification for all alarms.
+
+PyAlarm supports two ways of sending mails configured with the `MailMethod` class property:
+
+* using 'mail' shell command, when *MailMethod* is set to `mail`, which is default,
+* or using `smtplib` when *MailMethod* is set to `smtp[:host[:port]]`.
 
 Format of Alarm message
 

--- a/doc/PyAlarmUserGuide.rst
+++ b/doc/PyAlarmUserGuide.rst
@@ -443,6 +443,10 @@ PyAlarm supports two ways of sending mails configured with the `MailMethod` clas
 * using 'mail' shell command, when *MailMethod* is set to `mail`, which is default,
 * or using `smtplib` when *MailMethod* is set to `smtp[:host[:port]]`.
 
+When using *mail* method it setup *from* variable as '-S' option (see: https://linux.die.net/man/1/mail ).
+However, some setups may require to use `-r` option additionally. To enable it set `MailDashRoption` class property
+with a proper mail address.
+
 Format of Alarm message
 
 

--- a/panic/ds/PyAlarm.py
+++ b/panic/ds/PyAlarm.py
@@ -2307,7 +2307,8 @@ class PyAlarm(PyTango.Device_4Impl, fandango.log.Logger):
                 command = 'echo -e "'+format4sendmail(argin[0])+'" '
                 command += '| mail -s "%s" ' % argin[1]
                 command += '-S from=%s ' % self.FromAddress 
-                #'-r %s ' % (self.FromAddress)
+                if len(self.MailDashRoption) > 0:
+                    command += '-r %s ' % (self.MailDashRoption)
                 command += (argin[2] if isString(argin[2]) 
                                       else ','.join(argin[2]))
                 self.info( 'Launching mail command: '

--- a/panic/properties.py
+++ b/panic/properties.py
@@ -141,6 +141,10 @@ PANIC_PROPERTIES = {
         [PyTango.DevString,
          "mail or smtp[:host[:port]]",
          [ "mail" ] ],
+    'MailDashRoption':
+        [PyTango.DevString,
+         "If not empty, adds -r oprtion to the mail command with its value. Usefull to avoid 'sender address rejected' when sending from local domains.",
+         [ "" ] ],
     'FromAddress':
         [PyTango.DevString,
         "Address that will appear as Sender in mail and SMS",


### PR DESCRIPTION
Some mail servers may require usage of  `-r `  option when sending mails (as is the case for SOLARIS).
This fix provides a new property `MailDashRoption`, which, when set, allows to add `-r` option. Value of this property is added as the option value.